### PR TITLE
Add admin UI and security with user management

### DIFF
--- a/octopus-admin-ui/README.md
+++ b/octopus-admin-ui/README.md
@@ -1,0 +1,6 @@
+# Octopus Admin UI
+
+This module provides a very small React based single page used to manage short links.
+It loads existing links from `/api/url` and allows creating new ones.
+The project is intentionally simple and uses CDN hosted React scripts so no build step is required.
+Open `public/index.html` directly in the browser after starting `octopus-server`.

--- a/octopus-admin-ui/public/index.html
+++ b/octopus-admin-ui/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Octopus Admin</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/axios/dist/axios.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script src="../src/app.js"></script>
+</body>
+</html>

--- a/octopus-admin-ui/src/app.js
+++ b/octopus-admin-ui/src/app.js
@@ -1,0 +1,25 @@
+const e = React.createElement;
+
+function App() {
+  const [urls, setUrls] = React.useState([]);
+  const [longUrl, setLongUrl] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const load = () => {
+    axios.get('/api/url').then(res => setUrls(res.data));
+  };
+  const create = () => {
+    axios.post('/api/url', {longUrl, description}).then(load);
+  };
+  React.useEffect(load, []);
+  return e('div', null,
+    e('h1', null, 'Octopus Admin'),
+    e('div', null,
+      e('input', {value: longUrl, onChange: ev => setLongUrl(ev.target.value), placeholder:'Long URL'}),
+      e('input', {value: description, onChange: ev => setDescription(ev.target.value), placeholder:'Description'}),
+      e('button', {onClick:create}, 'Create')
+    ),
+    e('ul', null, urls.map(u => e('li', {key: u.id}, u.shortUrl)))
+  );
+}
+
+ReactDOM.render(e(App), document.getElementById('root'));

--- a/octopus-server/pom.xml
+++ b/octopus-server/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
         <dependency>

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/application/controller/OctopusController.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/application/controller/OctopusController.java
@@ -7,10 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -51,5 +48,21 @@ public class OctopusController {
         urlMapService.processTransform(context);
         // 这里有一个技巧,flush用到的线程和内部逻辑处理的线程不是同一个线程,所有要用到TTL
         return Mono.fromRunnable(context.getRedirectAction());
+    }
+
+    @PostMapping(path = "/api/url")
+    public String create(@RequestBody cn.throwx.octopus.server.model.entity.UrlMap body) {
+        return urlMapService.createUrlMap("localhost:9099", body);
+    }
+
+    @PutMapping(path = "/api/url/{id}")
+    public Long edit(@PathVariable("id") Long id, @RequestBody cn.throwx.octopus.server.model.entity.UrlMap body) {
+        body.setId(id);
+        return urlMapService.editUrlMap(body);
+    }
+
+    @DeleteMapping(path = "/api/url/{id}")
+    public void delete(@PathVariable("id") Long id) {
+        urlMapService.deleteUrlMap(id);
     }
 }

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/application/controller/UserController.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/application/controller/UserController.java
@@ -1,0 +1,47 @@
+package cn.throwx.octopus.server.application.controller;
+
+import cn.throwx.octopus.server.service.UserService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Data
+    public static class RegisterRequest {
+        private String username;
+        private String password;
+    }
+
+    @PostMapping("/register")
+    public Map<String, Object> register(@RequestBody RegisterRequest request) {
+        Long id = userService.register(request.getUsername(), request.getPassword());
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", id);
+        return map;
+    }
+
+    @Data
+    public static class LoginRequest {
+        private String username;
+        private String password;
+    }
+
+    @PostMapping("/login")
+    public Map<String, Object> login() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", "Please authenticate using HTTP Basic");
+        return map;
+    }
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/infra/config/SecurityConfiguration.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/infra/config/SecurityConfiguration.java
@@ -1,0 +1,36 @@
+package cn.throwx.octopus.server.infra.config;
+
+import cn.throwx.octopus.server.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableReactiveMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+
+    private final UserService userService;
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http.csrf().disable()
+            .authorizeExchange()
+            .pathMatchers("/user/register", "/user/login", "/{compressionCode}").permitAll()
+            .pathMatchers("/api/**").authenticated()
+            .anyExchange().permitAll()
+            .and()
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/model/entity/User.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/model/entity/User.java
@@ -1,0 +1,60 @@
+package cn.throwx.octopus.server.model.entity;
+
+import java.time.OffsetDateTime;
+
+public class User {
+    private Long id;
+    private String username;
+    private String password;
+    private Long roleId;
+    private OffsetDateTime createTime;
+    private OffsetDateTime editTime;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Long getRoleId() {
+        return roleId;
+    }
+
+    public void setRoleId(Long roleId) {
+        this.roleId = roleId;
+    }
+
+    public OffsetDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(OffsetDateTime createTime) {
+        this.createTime = createTime;
+    }
+
+    public OffsetDateTime getEditTime() {
+        return editTime;
+    }
+
+    public void setEditTime(OffsetDateTime editTime) {
+        this.editTime = editTime;
+    }
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/model/entity/UserRole.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/model/entity/UserRole.java
@@ -1,0 +1,22 @@
+package cn.throwx.octopus.server.model.entity;
+
+public class UserRole {
+    private Long id;
+    private String roleName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+
+    public void setRoleName(String roleName) {
+        this.roleName = roleName;
+    }
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/repository/UserDao.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/repository/UserDao.java
@@ -1,0 +1,7 @@
+package cn.throwx.octopus.server.repository;
+
+import cn.throwx.octopus.server.model.entity.User;
+import cn.throwx.octopus.server.repository.mapper.UserMapper;
+
+public interface UserDao extends UserMapper {
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/repository/UserRoleDao.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/repository/UserRoleDao.java
@@ -1,0 +1,7 @@
+package cn.throwx.octopus.server.repository;
+
+import cn.throwx.octopus.server.model.entity.UserRole;
+import cn.throwx.octopus.server.repository.mapper.UserRoleMapper;
+
+public interface UserRoleDao extends UserRoleMapper {
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/repository/mapper/UserMapper.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/repository/mapper/UserMapper.java
@@ -1,0 +1,12 @@
+package cn.throwx.octopus.server.repository.mapper;
+
+import cn.throwx.octopus.server.model.entity.User;
+import org.apache.ibatis.annotations.Param;
+
+public interface UserMapper {
+    int insertSelective(User user);
+
+    User selectByPrimaryKey(Long id);
+
+    User selectByUsername(@Param("username") String username);
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/repository/mapper/UserRoleMapper.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/repository/mapper/UserRoleMapper.java
@@ -1,0 +1,10 @@
+package cn.throwx.octopus.server.repository.mapper;
+
+import cn.throwx.octopus.server.model.entity.UserRole;
+import java.util.List;
+
+public interface UserRoleMapper {
+    UserRole selectByPrimaryKey(Long id);
+
+    List<UserRole> selectAll();
+}

--- a/octopus-server/src/main/java/cn/throwx/octopus/server/service/UserService.java
+++ b/octopus-server/src/main/java/cn/throwx/octopus/server/service/UserService.java
@@ -1,0 +1,44 @@
+package cn.throwx.octopus.server.service;
+
+import cn.throwx.octopus.server.model.entity.UserRole;
+import cn.throwx.octopus.server.repository.UserDao;
+import cn.throwx.octopus.server.repository.UserRoleDao;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+
+    private final UserDao userDao;
+    private final UserRoleDao userRoleDao;
+    private final PasswordEncoder passwordEncoder;
+
+    public Long register(String username, String rawPassword) {
+        cn.throwx.octopus.server.model.entity.User exist = userDao.selectByUsername(username);
+        if (exist != null) {
+            throw new RuntimeException("user exists");
+        }
+        cn.throwx.octopus.server.model.entity.User user = new cn.throwx.octopus.server.model.entity.User();
+        user.setUsername(username);
+        user.setPassword(passwordEncoder.encode(rawPassword));
+        user.setRoleId(1L);
+        userDao.insertSelective(user);
+        return user.getId();
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        cn.throwx.octopus.server.model.entity.User user = userDao.selectByUsername(username);
+        if (user == null) {
+            throw new RuntimeException("user not found");
+        }
+        UserRole role = userRoleDao.selectByPrimaryKey(user.getRoleId());
+        String roleName = role != null ? role.getRoleName() : "USER";
+        return User.withUsername(user.getUsername()).password(user.getPassword()).roles(roleName).build();
+    }
+}

--- a/octopus-server/src/main/resources/db/migration/V1__Init.sql
+++ b/octopus-server/src/main/resources/db/migration/V1__Init.sql
@@ -111,3 +111,17 @@ CREATE TABLE `transform_event_record`
     INDEX idx_long_url_digest (`long_url_digest`),
     INDEX idx_unique_identity (`unique_identity`)
 ) COMMENT '转换事件记录';
+CREATE TABLE `user_role` (
+    `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT '主键',
+    `role_name` VARCHAR(32) NOT NULL COMMENT '角色名称'
+) COMMENT '用户角色';
+
+CREATE TABLE `user` (
+    `id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT '主键',
+    `username` VARCHAR(64) NOT NULL COMMENT '用户名',
+    `password` VARCHAR(128) NOT NULL COMMENT '密码',
+    `role_id` BIGINT NOT NULL COMMENT '角色ID',
+    `create_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `edit_time` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    UNIQUE uniq_username (`username`)
+) COMMENT '用户表';

--- a/octopus-server/src/main/resources/mappings/base/UserMapper.xml
+++ b/octopus-server/src/main/resources/mappings/base/UserMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="cn.throwx.octopus.server.repository.mapper.UserMapper">
+    <resultMap id="BaseResultMap" type="cn.throwx.octopus.server.model.entity.User">
+        <id column="id" jdbcType="BIGINT" property="id"/>
+        <result column="username" jdbcType="VARCHAR" property="username"/>
+        <result column="password" jdbcType="VARCHAR" property="password"/>
+        <result column="role_id" jdbcType="BIGINT" property="roleId"/>
+        <result column="create_time" jdbcType="TIMESTAMP" property="createTime"/>
+        <result column="edit_time" jdbcType="TIMESTAMP" property="editTime"/>
+    </resultMap>
+    <sql id="Base_Column_List">
+        id, username, password, role_id, create_time, edit_time
+    </sql>
+    <select id="selectByPrimaryKey" resultMap="BaseResultMap">
+        select <include refid="Base_Column_List"/>
+        from user
+        where id = #{id}
+    </select>
+    <select id="selectByUsername" resultMap="BaseResultMap">
+        select <include refid="Base_Column_List"/>
+        from user
+        where username = #{username}
+    </select>
+    <insert id="insertSelective" parameterType="cn.throwx.octopus.server.model.entity.User" useGeneratedKeys="true" keyProperty="id">
+        insert into user
+        <trim prefix="(" suffix=")" suffixOverrides=",">
+            <if test="username != null">username,</if>
+            <if test="password != null">password,</if>
+            <if test="roleId != null">role_id,</if>
+        </trim>
+        <trim prefix="values (" suffix=")" suffixOverrides=",">
+            <if test="username != null">#{username},</if>
+            <if test="password != null">#{password},</if>
+            <if test="roleId != null">#{roleId},</if>
+        </trim>
+    </insert>
+</mapper>

--- a/octopus-server/src/main/resources/mappings/base/UserRoleMapper.xml
+++ b/octopus-server/src/main/resources/mappings/base/UserRoleMapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="cn.throwx.octopus.server.repository.mapper.UserRoleMapper">
+    <resultMap id="BaseResultMap" type="cn.throwx.octopus.server.model.entity.UserRole">
+        <id column="id" jdbcType="BIGINT" property="id"/>
+        <result column="role_name" jdbcType="VARCHAR" property="roleName"/>
+    </resultMap>
+    <sql id="Base_Column_List">
+        id, role_name
+    </sql>
+    <select id="selectByPrimaryKey" resultMap="BaseResultMap">
+        select <include refid="Base_Column_List"/>
+        from user_role
+        where id = #{id}
+    </select>
+    <select id="selectAll" resultMap="BaseResultMap">
+        select <include refid="Base_Column_List"/>
+        from user_role
+    </select>
+</mapper>


### PR DESCRIPTION
## Summary
- build `octopus-admin-ui` React module for managing links
- add Spring Security configuration
- add users and roles tables to schema
- support registering users and basic login instructions
- secure management endpoints and expose create/update/delete operations

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410baa33c08320be2fa58a7b6c5c9b